### PR TITLE
Change db

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ git_source(:github) do |repo_name|
 end
 
 gem 'rails', '~> 5.1.3'
+gem 'pg'
 gem 'bcrypt'
 gem 'sqlite3'
 gem 'puma', '~> 3.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,7 @@ GEM
     nio4r (2.1.0)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
+    pg (0.21.0)
     public_suffix (3.0.0)
     puma (3.10.0)
     rack (2.0.3)
@@ -202,6 +203,7 @@ DEPENDENCIES
   haml-rails
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
+  pg
   puma (~> 3.7)
   rails (~> 5.1.3)
   sass-rails (~> 5.0)
@@ -215,4 +217,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.15.1
+   1.15.4

--- a/app/controllers/tasks/days_controller.rb
+++ b/app/controllers/tasks/days_controller.rb
@@ -3,7 +3,7 @@ class Tasks::DaysController < ApplicationController
 
   def index
     @date = Time.new(params[:year], params[:month], params[:day])
-    @tasks = Task.where(user: current_user, start_at: @date.beginning_of_day..@date.end_of_day).or(Task.where(user: current_user, end_at: @date.beginning_of_day..@date.end_of_day)).map { |task| task.adjust_overnight_range(@date) }.sort_by { |t| t.start_at }
+    @tasks = Task.where(user: current_user, starts_at: @date.beginning_of_day..@date.end_of_day).or(Task.where(user: current_user, ends_at: @date.beginning_of_day..@date.end_of_day)).map { |task| task.adjust_overnight_range(@date) }.sort_by { |t| t.starts_at }
     @task = Task.new
   end
 end

--- a/app/controllers/tasks/months_controller.rb
+++ b/app/controllers/tasks/months_controller.rb
@@ -3,8 +3,8 @@ class Tasks::MonthsController < ApplicationController
 
   def index
     @date = Time.new(params[:year], params[:month])
-    tasks_by_start = Task.where(user: current_user, start_at: @date.beginning_of_month..@date.end_of_month).map { |task| task.adjust_overnight_range(task.start_at) }.group_by { |t| t.start_at.day }
-    tasks_by_end = Task.where(user: current_user, end_at: @date.beginning_of_month..@date.end_of_month).map { |task| task.adjust_overnight_range(task.end_at) }.group_by { |t| t.end_at.day }
-    @tasks = tasks_by_start.merge(tasks_by_end) { |_k, v1, v2| v1.concat(v2).uniq.sort_by { |t| t.start_at } }
+    tasks_by_start = Task.where(user: current_user, starts_at: @date.beginning_of_month..@date.end_of_month).map { |task| task.adjust_overnight_range(task.starts_at) }.group_by { |t| t.starts_at.day }
+    tasks_by_end = Task.where(user: current_user, ends_at: @date.beginning_of_month..@date.end_of_month).map { |task| task.adjust_overnight_range(task.ends_at) }.group_by { |t| t.ends_at.day }
+    @tasks = tasks_by_start.merge(tasks_by_end) { |_k, v1, v2| v1.concat(v2).uniq.sort_by { |t| t.starts_at } }
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -7,16 +7,16 @@ class TasksController < ApplicationController
     task.user = current_user
 
     if task.save!
-      @tasks = Task.where(user: current_user, start_at: task.start_at.beginning_of_day..task.start_at.end_of_day)
-      redirect_to tasks_days_path year: task.start_at.year, month: task.start_at.month, day: task.start_at.day
+      @tasks = Task.where(user: current_user, starts_at: task.starts_at.beginning_of_day..task.starts_at.end_of_day)
+      redirect_to tasks_days_path year: task.starts_at.year, month: task.starts_at.month, day: task.starts_at.day
     else
-      redirect_to tasks_months_path year: task.start_at.year, month: task.start_at.month
+      redirect_to tasks_months_path year: task.starts_at.year, month: task.starts_at.month
     end
   end
 
   private
 
     def task_params
-      params.require(:task).permit(:title, :start_at, :end_at)
+      params.require(:task).permit(:title, :starts_at, :ends_at)
     end
 end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -1,6 +1,6 @@
 module TasksHelper
   def show_time_range(task)
-    "#{l task.start_at, format: :time} ~ #{l task.end_at, format: :time}"
+    "#{l task.starts_at, format: :time} ~ #{l task.ends_at, format: :time}"
   end
 
   def set_time_select_to_now(date)

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,24 +2,29 @@ class Task < ApplicationRecord
   belongs_to :user
 
   def to_hours
-    ((end_at - start_at) / 60 / 60).to_i
+    ((ends_at - starts_at) / 60 / 60).to_i
   end
 
   def to_minutes
-    (((end_at - start_at) / 60) % 60).to_i
+    (((ends_at - starts_at) / 60) % 60).to_i
   end
 
   def is_overnight?
-    start_at.day != end_at.day
+    starts_at.day != ends_at.day
+  end
+
+  def over_end_of_month?
+    starts_at.month != ends_at.month
   end
 
   def adjust_overnight_range(date)
     return self unless is_overnight?
-    _task = self.clone
-    if start_at < date.beginning_of_day
-      _task.start_at = start_at.change(day: date.day, hour: 0, min: 0)
-    elsif end_at > date.end_of_day
-      _task.end_at = end_at.change(day: date.tomorrow.day, hour: 0, min: 0)
+    _task = self.dup
+    if starts_at < date.beginning_of_day
+      _task.starts_at = starts_at.change(day: date.day, hour: 0, min: 0)
+      _task.starts_at = starts_at.change(month: date.month, day: date.day, hour: 0, min: 0) if over_end_of_month?
+    elsif ends_at > date.end_of_day
+      _task.ends_at = ends_at.change(day: date.tomorrow.day, hour: 0, min: 0)
     end
     _task
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -19,7 +19,7 @@ class Task < ApplicationRecord
 
   def adjust_overnight_range(date)
     return self unless is_overnight?
-    _task = self.dup
+    _task = self.clone
     if starts_at < date.beginning_of_day
       _task.starts_at = starts_at.change(day: date.day, hour: 0, min: 0)
       _task.starts_at = starts_at.change(month: date.month, day: date.day, hour: 0, min: 0) if over_end_of_month?

--- a/app/views/tasks/days/index.html.haml
+++ b/app/views/tasks/days/index.html.haml
@@ -9,8 +9,8 @@
   = show_time_range(task)
   %br
 = form_for @task, url: tasks_path do |f|
-  = datetime_select 'task', 'start_at', { minute_step: 10, ampm: true, default: set_time_select_to_now(@date) }
-  = datetime_select 'task', 'end_at', { minute_step: 10, ampm: true, default: set_time_select_to_now(@date) }
+  = datetime_select 'task', 'starts_at', { minute_step: 10, ampm: true, default: set_time_select_to_now(@date) }
+  = datetime_select 'task', 'ends_at', { minute_step: 10, ampm: true, default: set_time_select_to_now(@date) }
   = f.text_field :title
   = f.hidden_field :year, value: params[:year]
   = f.hidden_field :month, value: params[:month]

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,5 +17,6 @@ module TimeLog
     config.i18n.default_locale = :ja
     config.time_zone = 'Tokyo'
     config.active_record.default_timezone = :local
+    config.active_record.time_zone_aware_types = [:datetime]
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,21 +5,23 @@
 #   gem 'sqlite3'
 #
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
+  database: kameda
+  host: localhost
+  username: 'kameda'
+  password: '1215'
+  port: 5432
 
 development:
   <<: *default
-  database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
 
 production:
   <<: *default
-  database: db/production.sqlite3

--- a/db/migrate/20170919013028_create_tasks.rb
+++ b/db/migrate/20170919013028_create_tasks.rb
@@ -1,8 +1,8 @@
 class CreateTasks < ActiveRecord::Migration[5.1]
   def change
     create_table :tasks do |t|
-      t.datetime :start_at
-      t.datetime :end_at
+      t.datetime :starts_at
+      t.datetime :ends_at
       t.string :title
       t.references :user, foreign_key: true
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,11 +12,14 @@
 
 ActiveRecord::Schema.define(version: 20170919013028) do
 
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
   create_table "tasks", force: :cascade do |t|
-    t.datetime "start_at"
-    t.datetime "end_at"
+    t.datetime "starts_at"
+    t.datetime "ends_at"
     t.string "title"
-    t.integer "user_id"
+    t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_tasks_on_user_id"
@@ -29,4 +32,5 @@ ActiveRecord::Schema.define(version: 20170919013028) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "tasks", "users"
 end


### PR DESCRIPTION
herokuを見据えて、早めにデータベースを変更。
内部的処理は、この段階でstarts_atとends_atを持つことに決定。
ただし、もし将来的にトラフィックが増えて、このコア部分のリファクタリングが必要になった場合は、発行SQLが軽くなる `starts_at` と `作業時間` を持つように変更する可能性がある。
この時、一つのSQL文でDBから多めに集合を取り、そこからはアプリ側で操作するだけで負担が減る。